### PR TITLE
Replace OnAccept to maintain callout event naming

### DIFF
--- a/CalloutAPI.cs
+++ b/CalloutAPI.cs
@@ -259,17 +259,17 @@ namespace CalloutAPI
         }
 
         /// <summary>
-        /// OnAccept will be called when the player accepts the call.
-        /// You must call base.OnAccept(args) to initialise the default properties
+        /// Sets up the blip with the <see cref="Location"/>'s area
+        /// Override if you need a custom blip
         /// </summary>
-        protected void OnAccept(float circleRadius = 75f, BlipColor color = BlipColor.Yellow, BlipSprite sprite = BlipSprite.BigCircle, int alpha = 100)
+        protected void InitBlip() 
         {
-            int blipHandle = AddBlipForRadius(this.Location.X, this.Location.Y, this.Location.Z, circleRadius);
-            this.Radius = circleRadius;
+            int blipHandle = AddBlipForRadius(this.Location.X, this.Location.Y, this.Location.Z, 75f);
+            this.Radius = 75f;
             this.Marker = new Blip(blipHandle);
-            this.Marker.Sprite = sprite;
-            this.Marker.Color = color;
-            this.Marker.Alpha = alpha;
+            this.Marker.Sprite = BlipSprite.BigCircle;
+            this.Marker.Color = BlipColor.Yellow;
+            this.Marker.Alpha = 100;
         }
 
         /// <summary>
@@ -292,6 +292,8 @@ namespace CalloutAPI
             {
                 this.AssignedPlayers.Add(closest);
             }
+
+            InitBlip();
         }
 
         /// <summary>

--- a/CalloutAPI.cs
+++ b/CalloutAPI.cs
@@ -276,7 +276,9 @@ namespace CalloutAPI
         /// Init() will be automatically invoked by the CalloutManager<br/>
         /// Define game logic here (eg. Spawn suspects,victims,vehicles)
         /// </summary>
-        public virtual async Task OnAccept() { }
+        public virtual async Task OnAccept() {
+            InitBlip();
+        }
 
         /// <summary>
         /// (Do not call it)<br/><br/>
@@ -292,8 +294,6 @@ namespace CalloutAPI
             {
                 this.AssignedPlayers.Add(closest);
             }
-
-            InitBlip();
         }
 
         /// <summary>

--- a/CalloutAPI.cs
+++ b/CalloutAPI.cs
@@ -246,7 +246,7 @@ namespace CalloutAPI
         /// Initialize callout information. Call this in your callout constructor.
         /// </summary>
         /// <param name="location">The location for your callout.</param>
-        protected void InitBase(Vector3 location)
+        protected void InitInfo(Vector3 location)
         {
             this.AssignedPlayers = new List<Ped>();
             this.AssignedPlayers.Add(Game.PlayerPed);
@@ -276,7 +276,7 @@ namespace CalloutAPI
         /// Init() will be automatically invoked by the CalloutManager<br/>
         /// Define game logic here (eg. Spawn suspects,victims,vehicles)
         /// </summary>
-        public virtual async Task Init() { }
+        public virtual async Task OnAccept() { }
 
         /// <summary>
         /// (Do not call it)<br/><br/>


### PR DESCRIPTION
As discussed on Discord, this is a proposal for implementing OnAccept more sensefully (imo). All function events with prefix `On` are overridable function events. However, `OnAccept`, which sounds like a function event, actually needs to be called manually in `OnStart`. And that even when `OnAccept` is not doing what it sounds like by it's name. It's basically just setting up the Marker blip, while `Task Init()` is the "real" `OnAccept()` function.

In this draft, the blip can still be manually changed by overriding `InitBlip()`, similar to how the callout data can be defined by setting it after calling `InitBase`. But the function now gets automatically called by `Task OnAccept()` and the `InitBlip` override is all you need to set a custom blip.

This draft also includes some other suggestions for naming, however these suggestions should not be the main point of this draft PR. I just came across these suggestions when working on this draft and think they make sense in this context.

Having `Task Init()`, `base()` and `BaseInit()`, this can be a bit confusing.
- Change `Task Init()` to `Task OnAccept()` because this is actually the function that get's ran when a player accepts the callout.
- Change `Init()`to `InitInfo()`. This should avoid confusion with `base()` and to me sounds a bit more verbose, actually describing what the function is initializing.

These changes sure seem excessive at first glance, but FivePD is still at it's beginning of a hopefully long lifetime, and at a later point with possibly more events added, this may become more and more confusing. Therefore I ask you to look at these proposals and may consider some of them.

Alternatively please rename the `OnAccept()` just to `InitBlip()` so devs can handle it similar to how they do it with `InitBase()` right now. Then the name would make sense at least.